### PR TITLE
Update junit_reporter.js

### DIFF
--- a/src/junit_reporter.js
+++ b/src/junit_reporter.js
@@ -32,11 +32,11 @@
             pad(d.getSeconds());
     }
     function escapeInvalidXmlChars(str) {
-        return str.replace(/</g, "&lt;")
+        return str.replace(/\&/g, "&amp;")
+            .replace(/</g, "&lt;")
             .replace(/\>/g, "&gt;")
             .replace(/\"/g, "&quot;")
-            .replace(/\'/g, "&apos;")
-            .replace(/\&/g, "&amp;");
+            .replace(/\'/g, "&apos;");
     }
     function getQualifiedFilename(path, filename, separator) {
         if (path && path.substr(-1) !== separator && filename.substr(0) !== separator) {


### PR DESCRIPTION
Fix for over-escaping invalid XML-Characters.
In the original version, a failure text like:

<Expected ' ' to be 'some text'> 

is written like this into the XML file:

<Expected &amp;apos;&amp;apos; to be &amp;apos;some text&amp;apos;>

Correct would be:

<Expected &apos;&apos; to be &apos;some text&apos;>
